### PR TITLE
Add onConstruct method on backends

### DIFF
--- a/server/backends/backend.php
+++ b/server/backends/backend.php
@@ -48,6 +48,10 @@
                         $this->uid = loadBackend("users")->getUidByLogin($this->login);
                         break;
                 }
+
+                if (true === method_exists(static::class, 'onConstruct')) {
+                    $this->onConstruct();
+                }
             }
 
             /**


### PR DESCRIPTION
This will allow, if necessary, to perform additional actions of initializing the descendants of the backend object without overriding the constructor and avoid confusion of constructor arguments

```
class my extends backend
{
    public function onConstruct()
    {
        // Some additional initializations
    }
}
```