### PR TITLE
Fix: broken hikvision get camshot

### DIFF
--- a/server/hw/ip/common/hikvision/hikvision.php
+++ b/server/hw/ip/common/hikvision/hikvision.php
@@ -130,6 +130,10 @@ trait hikvision
         $res = curl_exec($ch);
         curl_close($ch);
 
+        if (str_starts_with(curl_getinfo($ch, CURLINFO_CONTENT_TYPE), 'image')) {
+            return (string) $res;
+        }
+
         if (curl_getinfo($ch, CURLINFO_CONTENT_TYPE) == 'application/xml') {
             return json_decode(json_encode(simplexml_load_string($res)), true);
         }


### PR DESCRIPTION
Camera returns camshot as image, but `server/hw/ip/common/hikvision/hikvision::apiCall()` method can not returning binary data