### PR TITLE
bugfix in authentication.php

### DIFF
--- a/server/backends/authentication/authentication.php
+++ b/server/backends/authentication/authentication.php
@@ -42,7 +42,7 @@
                     if (count($keys) > $this->config["redis"]["max_allowed_tokens"]) {
                         foreach ($keys as $key) {
                             try {
-                                $auth = json_decode($this->redis->get($key));
+                                $auth = json_decode($this->redis->get($key), true);
                                 if (@(int)$auth["updated"] < $first_key_time) {
                                     $first_key = $key;
                                 }


### PR DESCRIPTION
не хватало второго параметра у json_decode из-за чего возникала ошибка:

2024/07/04 18:20:52 [error] 2883242#2883242: *1888237 FastCGI sent in stderr: "PHP message: PHP Fatal error:  Uncaught Error: Cannot use object of type stdClass as array in /opt/rbt/server/backends/authentication/authentication.php:46 Stack trace:
#0 /opt/rbt/server/api/authentication/login.php(55): backends\authentication\authentication->login() #1 /opt/rbt/server/frontend.php(336): api\authentication\login::POST() #2 {main}
  thrown in /opt/rbt/server/backends/authentication/authentication.php on line 46" while reading response header from upstream, client: 172.21.109.3, server: , request: "POST /frontend/authentication/login HTTP/2.0", upstream: "fastcgi://unix:/var/run/php/php-fpm.sock:", host: "dom.a-home.biz", referrer: "https://dom.a-home.biz/"