### PR TITLE
fix: apply safe asterisk call-site fixes

### DIFF
--- a/client/modules/asterisk/asterisk.js
+++ b/client/modules/asterisk/asterisk.js
@@ -195,7 +195,7 @@
         }
         if (number) {
             if (modules.asterisk.currentSession && modules.asterisk.extension(modules.asterisk.currentSession.remote_identity.uri) == number) {
-                hmodules.asterisk.hangup();
+                modules.asterisk.hangup();
             } else {
                 if (!modules.asterisk.currentSession) {
                     modules.asterisk.ua.call(number, modules.asterisk.options);
@@ -245,7 +245,7 @@
             modules.asterisk.holdedSession = modules.asterisk.currentSession;
             modules.asterisk.currentSession = false;
             if (dialAfterHold) {
-                ua.call(dialAfterHold, options);
+                modules.asterisk.ua.call(dialAfterHold, modules.asterisk.options);
             }
             modules.asterisk.updateButton();
         }
@@ -279,7 +279,7 @@
         if (modules.asterisk.currentSession && modules.asterisk.currentSession.data == 'incoming') {
             modules.asterisk.currentSession.data = 'accepted';
             modules.asterisk.currentSession.answered = true;
-            modules.asterisk.currentSession.answer(options);
+            modules.asterisk.currentSession.answer(modules.asterisk.options);
             modules.asterisk.currentSession.connection.addEventListener('addstream', modules.asterisk.addStream);
         }
         modules.asterisk.updateButton();

--- a/client/modules/asterisk/asterisk.js
+++ b/client/modules/asterisk/asterisk.js
@@ -45,7 +45,7 @@
 
             modules.asterisk.ua.on('newRTCSession', modules.asterisk.newRTCSession);
 
-            modules.asterisk.ua.on('connected', modules.asterisk.onConnectionBroken);
+            modules.asterisk.ua.on('connected', modules.asterisk.onConnected);
             modules.asterisk.ua.on('disconnected', modules.asterisk.onConnectionBroken);
             modules.asterisk.ua.on('unregistered', modules.asterisk.onConnectionBroken);
 
@@ -120,6 +120,10 @@
                 });
             });
         }
+    },
+
+    onConnected: function () {
+        modules.asterisk.updateButton();
     },
 
     onConnectionBroken: function () {


### PR DESCRIPTION
This PR contains only the first three low-risk fixes split out from #98.

Changes:
- fix typo in hangup call
- use modules.asterisk.ua and modules.asterisk.options in hold flow
- use modules.asterisk.options when answering incoming calls

This intentionally excludes the reconnect lifecycle refactor so WS behavior can be verified separately.