### PR TITLE
feat: add configurable entrances display modes

### DIFF
--- a/server/config/config.sample.json5
+++ b/server/config/config.sample.json5
@@ -29,6 +29,8 @@
         "guest_access": "turnOnOnly",
         // How to show cameras in the mobile app. One of: list, tree, userDefined. List(default) - cameras are shown on the map; tree - cameras are shown as a tree structure; userDefined - user has a switch in the common settings
         "cctv_view": "list",
+        // How to show entrances on the main screen. One of: list, preview. List(default) - entrances are shown as a list; preview - entrances are shown with previews
+        "entrances_view": "list",
         // Active app's tab at start. One of: addresses, notifications, chat, pay, menu. The default value is addresses
         "active_tab": "addresses",
 

--- a/server/mobile/ext/options.php
+++ b/server/mobile/ext/options.php
@@ -24,6 +24,7 @@
      * @apiSuccess {String="turnOnOnly","turnOnAndOff"} [guestAccess = "turnOnOnly"] Тип гостевого доступа.
      * @apiSuccess {Number} [version] Версия API
      * @apiSuccess {String="list","tree","userDefined"} [cctvView="list"] How to show cameras in the mobile app. list(default) - cameras are shown on the map; tree - cameras are shown as a tree structure; userDefined - user has a switch in the common settings
+     * @apiSuccess {String="list","preview"} [entrancesView="list"] How to show entrances on the main screen. list(default) - entrances are shown as a list; preview - entrances are shown with previews
      * @apiSuccess {String="addresses", "notifications", "chat", "pay", "menu"} [activeTab="addresses"] Active app's tab at start.
      * @apiSuccess {String} [validationNamePattern=""] Regex validation pattern for a name
      * @apiSuccess {String} [validationPatronymicPattern=""] Regex validation pattern for a patronymic
@@ -86,6 +87,9 @@
     if (@$config["mobile"]["cctv_view"]) {
         $response["cctvView"] = $config["mobile"]["cctv_view"];
     }
+
+    $entrancesView = @$config["mobile"]["entrances_view"] ?: "list";
+    $response["entrancesView"] = in_array($entrancesView, [ "list", "preview" ]) ? $entrancesView : "list";
 
     if (@$config["mobile"]["active_tab"]) {
         $response["activeTab"] = $config["mobile"]["active_tab"];


### PR DESCRIPTION
Introduce a mobile option to switch how entrances are shown on the main screen

- add entrances_view to the config sample
- expose entrancesView in the mobile options response
- support list and preview modes with a safe default fallback