### PR TITLE
Add Sesame DVR media server type

### DIFF
--- a/server/backends/dvr/internal/internal.php
+++ b/server/backends/dvr/internal/internal.php
@@ -85,7 +85,7 @@
                 }
 
                 // Если токен явно присутствует в DVR-URL Flussonic, то используем его.
-                if ($dvrServer['type'] == 'flussonic') {
+                if ($dvrServer['type'] == 'flussonic' || $dvrServer['type'] == 'sesame') {
 
                     $parsed_url = parse_url($cam['dvrStream']);
 
@@ -137,7 +137,7 @@
                 $dvrServer = $this->getDVRServerForCam($cam);
 
                 // для Flussonic приводим URL к виду: https://host/stream_name
-                if ($dvrServer['type'] == 'flussonic') {
+                if ($dvrServer['type'] == 'flussonic' || $dvrServer['type'] == 'sesame') {
                     $parsed_url = parse_url($dvrStream);
 
                     $scheme   = isset($parsed_url['scheme']) ? $parsed_url['scheme'] . '://' : '';

--- a/server/config/config.sample.json5
+++ b/server/config/config.sample.json5
@@ -193,7 +193,7 @@
             "servers": [
                 {
                     "title": "Local server",
-                    "type": "nimble or flussonic or trassir",
+                    "type": "nimble or flussonic or sesame or trassir",
                     "url": "https://video.server.hostname:8443",
                     "token": "<!-- mediaserver security token here (only if you use it) --!>",
                     "hlsMode": "mpegts",


### PR DESCRIPTION
## Summary
- Add `sesame` as an explicit DVR media server type in the sample config.
- Treat `type: "sesame"` as Flussonic-compatible for the two places where RBT previously checked `type == "flussonic"` explicitly:
  - token extraction from DVR URL query;
  - DVR stream URL normalization to `scheme://host/stream`.

Everything else already falls through to the existing Flussonic-compatible default branch, so this PR intentionally keeps the change minimal.

## Testing
- `git diff --check`

Not run: `php -l` / PHP tests, because PHP CLI is not installed in this environment.
