### PR TITLE
Load i18n for each custom submodule

### DIFF
--- a/client/js/app.js
+++ b/client/js/app.js
@@ -981,15 +981,48 @@ function loadSubModules(parent, subModules, doneOrParentObject) {
     }
 }
 
+function loadCustomSubModuleI18n(parent, module, done) {
+    let l = lStore("_lang");
+    if (!l) {
+        l = config.defaultLanguage;
+    }
+    if (!l) {
+        l = "ru";
+    }
+
+    $.get("modules/" + parent + "/custom/" + module + "/i18n/" + l + ".json?ver=" + version, i18n => {
+        if (i18n.errors) {
+            if (!lang.errors) {
+                lang.errors = {};
+            }
+            lang.errors = mergeDeep(lang.errors, i18n.errors);
+            delete i18n.errors;
+        }
+        if (i18n.methods) {
+            if (!lang.methods) {
+                lang.methods = {};
+            }
+            lang.methods = mergeDeep(lang.methods, i18n.methods);
+            delete i18n.methods;
+        }
+        if (!lang[parent]) {
+            lang[parent] = {};
+        }
+        lang[parent] = mergeDeep(lang[parent], i18n);
+    }).always(done);
+}
+
 function loadCustomSubModules(parent, subModules) {
     let module = subModules.shift();
     if (!module) {
         loadModule();
     } else{
-        $.getScript("modules/" + parent + "/custom/" + module + ".js?ver=" + version).
-        done(() => {
-            loadCustomSubModules(parent, subModules);
-        }).
-        fail(FAIL);
+        loadCustomSubModuleI18n(parent, module, () => {
+            $.getScript("modules/" + parent + "/custom/" + module + ".js?ver=" + version).
+            done(() => {
+                loadCustomSubModules(parent, subModules);
+            }).
+            fail(FAIL);
+        });
     }
 }


### PR DESCRIPTION
## Summary
- keep the existing module-wide custom i18n overlay for compatibility
- before loading each custom submodule JS, try to load `modules/<parent>/custom/<submodule>/i18n/<lang>.json`
- merge per-submodule `errors`, `methods`, and module translations the same way as the existing custom i18n loader

## Why
Multiple independent customizations can now ship their own translations without overwriting the shared `modules/<parent>/custom/i18n/<lang>.json` file.

## Checks
- `node --check client/js/app.js`
- `git diff --check`