### PR TITLE
Allow camera stream URLs beyond RTSP

### DIFF
--- a/client/modules/addresses/cameras.js
+++ b/client/modules/addresses/cameras.js
@@ -154,11 +154,11 @@
                     id: "stream",
                     type: "text",
                     title: i18n("addresses.stream"),
-                    placeholder: "rtsp://",
+                    placeholder: "rtsp://, http://, https://",
                     validate: v => {
                         if (v) {
                             try {
-                                if (!/^rtsp:\/\/.+/.test(v)) {
+                                if (!/^(rtsp|https?):\/\/.+/.test(v)) {
                                     throw new Error();
                                 }
                                 new URL(v);
@@ -590,12 +590,12 @@
                         id: "stream",
                         type: "text",
                         title: i18n("addresses.stream"),
-                        placeholder: "rtsp://",
+                        placeholder: "rtsp://, http://, https://",
                         value: camera.stream,
                         validate: v => {
                             if (v) {
                                 try {
-                                    if (!/^rtsp:\/\/.+/.test(v)) {
+                                    if (!/^(rtsp|https?):\/\/.+/.test(v)) {
                                         throw new Error();
                                     }
                                     new URL(v);

--- a/client/modules/addresses/i18n/en.json
+++ b/client/modules/addresses/i18n/en.json
@@ -215,7 +215,7 @@
     "flatSipCall": "Call to flat [sip intercom]",
     "cameras": "Cameras",
     "addCamera": "Add camera",
-    "stream": "Camera RTSP stream",
+    "stream": "Camera stream URL",
     "deleteCamera": "Delete camera",
     "modifyCamera": "Edit camera",
     "confirmDeleteCamera": "Delete camera \"#%s\"?",

--- a/client/modules/addresses/i18n/ru.json
+++ b/client/modules/addresses/i18n/ru.json
@@ -215,7 +215,7 @@
     "flatSipCall": "Позвонить в квартиру [sip intercom]",
     "cameras": "Камеры",
     "addCamera": "Добавить камеру",
-    "stream": "RTSP поток камеры",
+    "stream": "URL потока камеры",
     "deleteCamera": "Удалить камеру",
     "modifyCamera": "Редактирование камеры",
     "confirmDeleteCamera": "Удалить камеру \"#%s\"?",


### PR DESCRIPTION
## Summary
- rename the camera source field label from RTSP-specific wording to a generic stream URL label
- allow `rtsp://`, `http://`, and `https://` values in the camera `stream` field form validation
- update the stream field placeholder to show the accepted schemes

## Validation
- `node --check client/modules/addresses/cameras.js`
- `python3 -m json.tool client/modules/addresses/i18n/ru.json`
- `python3 -m json.tool client/modules/addresses/i18n/en.json`