### PR TITLE
Add inbox message endpoint by mobile

### DIFF
--- a/server/api/inbox/messageByMobile.php
+++ b/server/api/inbox/messageByMobile.php
@@ -1,0 +1,84 @@
+<?php
+
+    /**
+     * @api {post} /api/inbox/messageByMobile send message by subscriber mobile
+     *
+     * @apiVersion 1.0.0
+     *
+     * @apiName sendMessageByMobile
+     * @apiGroup inbox
+     *
+     * @apiHeader {String} Authorization authentication token
+     *
+     * @apiBody {String} mobile subscriber mobile phone number
+     * @apiBody {String} title
+     * @apiBody {String} body
+     * @apiBody {String="inbox","money"} [action="inbox"]
+     *
+     * @apiSuccess {Object} sent
+     */
+
+    /**
+     * inbox api
+     */
+
+    namespace api\inbox {
+
+        use api\api;
+
+        /**
+         * messageByMobile method
+         */
+
+        class messageByMobile extends api {
+
+            public static function POST($params) {
+                $mobile = preg_replace('/[\s\-()]/', '', trim((string)@$params["mobile"]));
+                $title = @$params["title"];
+                $body = @$params["body"];
+                $action = @$params["action"];
+                $action = (is_string($action) && trim($action)) ? trim($action) : "inbox";
+
+                if (!$mobile || !is_string($title) || !trim($title) || !is_string($body) || !trim($body)) {
+                    setLastError("invalidParams");
+                    return api::ANSWER(false);
+                }
+
+                $households = loadBackend("households");
+                $subscribers = $households->getSubscribers("mobile", $mobile, [ "noDetail" ]);
+
+                if ($subscribers === false) {
+                    return api::ANSWER(false);
+                }
+
+                if (!count($subscribers)) {
+                    setLastError("mobileSubscriberNotRegistered");
+                    return api::ANSWER(false, "notFound");
+                }
+
+                if (count($subscribers) > 1) {
+                    setLastError("mobileSubscriberNotUnique");
+                    return api::ANSWER(false);
+                }
+
+                $subscriber = $subscribers[0];
+                $inbox = loadBackend("inbox");
+
+                $success = $inbox->sendMessage($subscriber["subscriberId"], $title, $body, $action);
+
+                if ($success !== false) {
+                    $success["subscriberId"] = $subscriber["subscriberId"];
+                    $success["mobile"] = $subscriber["mobile"];
+                    $success["pushSent"] = (int)$success["count"] > 0;
+                }
+
+                return api::ANSWER($success, ($success !== false) ? "sent" : "notAcceptable");
+            }
+
+            public static function index() {
+                return [
+                    "POST" => "#same(addresses,house,PUT)",
+                ];
+            }
+        }
+    }


### PR DESCRIPTION
## Summary
- add `POST /api/inbox/messageByMobile` to send inbox/push messages by subscriber mobile number
- resolve exact mobile to a unique subscriber before delegating to existing inbox `sendMessage` flow
- return subscriber metadata plus `pushSent` based on delivered push count

## API
`POST /api/inbox/messageByMobile`

Body:
```json
{
  "mobile": "+79991234567",
  "title": "Title",
  "body": "Message body",
  "action": "inbox"
}
```

`action` defaults to `inbox`.

## Checks
- `docker run --rm -v "$PWD":/src -w /src php:8.1-cli php -l server/api/inbox/messageByMobile.php`
- `git diff --check`