### PR TITLE
Use billing services in mobile getServices

### DIFF
--- a/server/mobile/geo/getServices.php
+++ b/server/mobile/geo/getServices.php
@@ -31,6 +31,7 @@
 
     $ret = [];
     $services = [];
+    $defaultServices = [];
     $allowedServices = [
         "internet",
         "iptv",
@@ -60,11 +61,16 @@
     if ($households->getFlats('houseId', $house_id)) {
         if (!count($services)) {
             $services = [ "domophone" => "domophone" ];
+            $defaultServices = [ "domophone" => "domophone" ];
         }
 
         foreach ($services as $service) {
             $s = $RBTServices[$service];
-            $s['byDefault'] = 't';
+
+            if (isset($defaultServices[$service])) {
+                $s['byDefault'] = 't';
+            }
+
             $ret[] = $s;
         }
     }

--- a/server/mobile/geo/getServices.php
+++ b/server/mobile/geo/getServices.php
@@ -31,7 +31,6 @@
 
     $ret = [];
     $services = [];
-    $defaultServices = [];
     $allowedServices = [
         "internet",
         "iptv",
@@ -61,16 +60,11 @@
     if ($households->getFlats('houseId', $house_id)) {
         if (!count($services)) {
             $services = [ "domophone" => "domophone" ];
-            $defaultServices = [ "domophone" => "domophone" ];
         }
 
         foreach ($services as $service) {
             $s = $RBTServices[$service];
-
-            if (isset($defaultServices[$service])) {
-                $s['byDefault'] = 't';
-            }
-
+            $s['byDefault'] = @$s['canChange'] === 'f' ? 't' : 'f';
             $ret[] = $s;
         }
     }

--- a/server/mobile/geo/getServices.php
+++ b/server/mobile/geo/getServices.php
@@ -64,7 +64,8 @@
 
         foreach ($services as $service) {
             $s = $RBTServices[$service];
-            $s['byDefault'] = @$s['canChange'] === 'f' ? 't' : 'f';
+            $s['canChange'] = 't';
+            $s['byDefault'] = $service === 'domophone' ? 't' : 'f';
             $ret[] = $s;
         }
     }

--- a/server/mobile/geo/getServices.php
+++ b/server/mobile/geo/getServices.php
@@ -27,14 +27,46 @@
         response(422);
     }
     $households = loadBackend("households");
+    $customFields = loadBackend("customFields");
 
     $ret = [];
+    $services = [];
+    $allowedServices = [
+        "internet",
+        "iptv",
+        "ctv",
+        "phone",
+        "cctv",
+        "domophone",
+        "gsm",
+    ];
 
+    if ($customFields) {
+        $values = $customFields->getValues("house", $house_id);
+
+        if (is_array($values)) {
+            $servicesValue = trim((string)@$values["services"]);
+
+            foreach (explode(",", $servicesValue) as $service) {
+                $service = trim(mb_strtolower($service));
+
+                if (in_array($service, $allowedServices, true) && isset($RBTServices[$service])) {
+                    $services[$service] = $service;
+                }
+            }
+        }
+    }
 
     if ($households->getFlats('houseId', $house_id)) {
-        $s = $RBTServices['domophone'];
-        $s['byDefault'] = 't';
-        $ret[] = $s;
+        if (!count($services)) {
+            $services = [ "domophone" => "domophone" ];
+        }
+
+        foreach ($services as $service) {
+            $s = $RBTServices[$service];
+            $s['byDefault'] = 't';
+            $ret[] = $s;
+        }
     }
 
 


### PR DESCRIPTION
## Summary
- read house `services` custom field populated by billing import in `/mobile/geo/getServices`
- return configured service cards when the field contains known service identifiers
- keep the current domophone fallback when no services are configured

## Verification
- `git diff --check`
- `php -l server/mobile/geo/getServices.php` was not run: PHP CLI is not installed in this environment