### PR TITLE
[codex] Allow empty flat floor when modifying flats

### DIFF
--- a/server/backends/households/internal/internal.php
+++ b/server/backends/households/internal/internal.php
@@ -916,6 +916,10 @@
                         $params["password"] = null;
                     }
 
+                    if (array_key_exists("floor", $params) && !is_array($params["floor"]) && trim((string)$params["floor"]) === "") {
+                        $params["floor"] = 0;
+                    }
+
                     if (array_key_exists("floor", $params) && !checkInt($params["floor"])) {
                         setLastError("invalidParams");
                         return false;


### PR DESCRIPTION
## Summary

- Normalize an empty `floor` value to `0` in `modifyFlat()` before integer validation.
- Keep existing validation for non-empty invalid floor values unchanged.

## Root cause

The flat edit form can submit an empty string for `floor`. The backend currently validates any present `floor` value with `checkInt()`, so an otherwise valid `PUT /houses/flat/:flatId` fails with `invalidParams` before fields like `contract`, `login`, or `password` can be saved.

`0` is already used by `getFlat()`/the database as the empty floor value, so normalizing the blank form value to `0` preserves existing behavior while allowing the rest of the flat update to proceed.

## Validation

- `php -l server/backends/households/internal/internal.php`