### PR TITLE
Filter cameras by path group visibility

### DIFF
--- a/client/modules/addresses/houses.js
+++ b/client/modules/addresses/houses.js
@@ -2420,6 +2420,11 @@
                 pathFirst = false;
             }
 
+            function validVisibleForFlats(value) {
+                value = $.trim(value);
+                return !value || /^\d+\s*(?:-\s*\d+\s*)?(?:,\s*\d+\s*(?:-\s*\d+\s*)?)*$/.test(value);
+            }
+
             cardForm({
                 title: i18n("addresses.path"),
                 footer: true,
@@ -2438,12 +2443,14 @@
                         addRoot: function (instance) {
                             POST("houses", "path", treeName, {
                                 text: i18n("addresses.newNode"),
+                                visibleForFlats: "",
                             }).done(result => {
                                 if (result && result.nodeId) {
                                     let node = {
                                         id: result.nodeId,
                                         text: i18n("addresses.newNode"),
                                         viewType: "list",
+                                        visibleForFlats: "",
                                     };
                                     instance.jstree().create_node("#", node, 'last', newNode => {
                                         setTimeout(() => {
@@ -2461,12 +2468,14 @@
                             parent = parent.length ? parent[0] : "#";
                             POST("houses", "path", (parent === "#") ? treeName : parent, {
                                 text: i18n("addresses.newNode"),
+                                visibleForFlats: "",
                             }).done(result => {
                                 if (result && result.nodeId) {
                                     let node = {
                                         id: result.nodeId,
                                         text: i18n("addresses.newNode"),
                                         viewType: "list",
+                                        visibleForFlats: "",
                                     };
                                     modules.addresses.houses.pathNodes[result.nodeId] = i18n("addresses.newNode");
                                     instance.jstree().create_node(parent, node, 'last', newNode => {
@@ -2564,6 +2573,14 @@
                         ],
                     },
                     {
+                        id: "pathVisibleForFlats",
+                        type: "text",
+                        title: i18n("addresses.pathVisibleForFlats"),
+                        placeholder: "1,3,10-20",
+                        hint: i18n("addresses.pathVisibleForFlatsHint"),
+                        validate: validVisibleForFlats,
+                    },
+                    {
                         id: "pathOrder",
                         type: "text",
                         title: i18n("addresses.pathOrder"),
@@ -2581,16 +2598,18 @@
                         return false;
                     }
 
-                    function syncPathViewType() {
+                    function syncPathSettings() {
                         let node = selectedPathNode();
                         if (node) {
                             $(`#${prefix}pathViewType`).prop("disabled", false).val(node.original && node.original.viewType ? node.original.viewType : "list");
+                            $(`#${prefix}pathVisibleForFlats`).prop("disabled", false).val(node.original && node.original.visibleForFlats !== null && typeof node.original.visibleForFlats !== "undefined" ? node.original.visibleForFlats : "");
                         } else {
                             $(`#${prefix}pathViewType`).prop("disabled", true).val("list");
+                            $(`#${prefix}pathVisibleForFlats`).prop("disabled", true).val("");
                         }
                     }
 
-                    $(`#${prefix}path`).off("select_node.jstree.cctvType deselect_node.jstree.cctvType changed.jstree.cctvType ready.jstree.cctvType").on("select_node.jstree.cctvType deselect_node.jstree.cctvType changed.jstree.cctvType ready.jstree.cctvType", syncPathViewType);
+                    $(`#${prefix}path`).off("select_node.jstree.cctvPathSettings deselect_node.jstree.cctvPathSettings changed.jstree.cctvPathSettings ready.jstree.cctvPathSettings").on("select_node.jstree.cctvPathSettings deselect_node.jstree.cctvPathSettings changed.jstree.cctvPathSettings ready.jstree.cctvPathSettings", syncPathSettings);
                     $(`#${prefix}pathViewType`).off("change.cctvType").on("change.cctvType", () => {
                         let node = selectedPathNode();
                         if (!node) {
@@ -2608,7 +2627,29 @@
                         }).
                         fail(FAIL);
                     });
-                    syncPathViewType();
+                    $(`#${prefix}pathVisibleForFlats`).off("change.cctvVisibleForFlats").on("change.cctvVisibleForFlats", () => {
+                        let node = selectedPathNode();
+                        if (!node) {
+                            return;
+                        }
+
+                        let visibleForFlats = $.trim($(`#${prefix}pathVisibleForFlats`).val());
+                        if (!validVisibleForFlats(visibleForFlats)) {
+                            return;
+                        }
+
+                        PUT("houses", "path", node.id, {
+                            text: node.text,
+                            type: node.original && node.original.viewType ? node.original.viewType : "list",
+                            visibleForFlats: visibleForFlats,
+                        }).
+                        done(() => {
+                            node.original = node.original || {};
+                            node.original.visibleForFlats = visibleForFlats;
+                        }).
+                        fail(FAIL);
+                    });
+                    syncPathSettings();
                 },
                 callback: result => {
                     let pathOrder = $.trim(`${result.pathOrder}`);

--- a/client/modules/addresses/i18n/en.json
+++ b/client/modules/addresses/i18n/en.json
@@ -372,6 +372,8 @@
     "pathViewType": "Group view mode",
     "pathViewTypeList": "List",
     "pathViewTypeMap": "Map",
+    "pathVisibleForFlats": "Visible for flats",
+    "pathVisibleForFlatsHint": "Empty inherits from parent",
     "pathOrder": "Order in group",
     "confirmDeleteNode": "Delete node \"%s\"?",
     "deleteNode": "Delete node",

--- a/client/modules/addresses/i18n/ru.json
+++ b/client/modules/addresses/i18n/ru.json
@@ -379,6 +379,8 @@
     "pathViewType": "Режим отображения группы",
     "pathViewTypeList": "Список",
     "pathViewTypeMap": "Карта",
+    "pathVisibleForFlats": "Видна квартирам",
+    "pathVisibleForFlatsHint": "Пусто — наследовать от родителя",
     "pathOrder": "Порядок в группе",
     "confirmDeleteNode": "Удалить элемент \"%s\"?",
     "deleteNode": "Удалить элемент",

--- a/server/api/houses/path.php
+++ b/server/api/houses/path.php
@@ -33,6 +33,7 @@
      * @apiBody {String} text
      * @apiBody {String} icon
      * @apiBody {String="list","map"} [type=list]
+     * @apiBody {String} [visibleForFlats] comma-separated flat numbers and ranges, e.g. "1,3,10-20"; empty inherits from parent
      *
      * @apiSuccess {Number} nodeId
      */
@@ -51,6 +52,7 @@
      * @apiBody {String} text
      * @apiBody {String} icon
      * @apiBody {String="list","map"} [type]
+     * @apiBody {String} [visibleForFlats] comma-separated flat numbers and ranges, e.g. "1,3,10-20"; empty inherits from parent
      *
      * @apiSuccess {Boolean} oprationResult
      */
@@ -109,9 +111,9 @@
                     return api::ERROR();
                 } else {
                     if ((int)$params["_id"]) {
-                        return api::ANSWER($households->addPathNode($params["_id"], @$params["text"], @$params["icon"], @$params["type"] ?: "list"), "nodeId");
+                        return api::ANSWER($households->addPathNode($params["_id"], @$params["text"], @$params["icon"], @$params["type"] ?: "list", @$params["visibleForFlats"]), "nodeId");
                     } else {
-                        return api::ANSWER($households->addRootPathNode($params["_id"], @$params["text"], @$params["icon"], @$params["type"] ?: "list"), "nodeId");
+                        return api::ANSWER($households->addRootPathNode($params["_id"], @$params["text"], @$params["icon"], @$params["type"] ?: "list", @$params["visibleForFlats"]), "nodeId");
                     }
                 }
             }
@@ -122,7 +124,9 @@
                 if (!$households) {
                     return api::ERROR();
                 } else {
-                    return api::ANSWER($households->modifyPathNode($params["_id"], @$params["text"], @$params["icon"], @$params["type"]));
+                    $visibleForFlats = array_key_exists("visibleForFlats", $params) ? $params["visibleForFlats"] : false;
+
+                    return api::ANSWER($households->modifyPathNode($params["_id"], @$params["text"], @$params["icon"], @$params["type"], $visibleForFlats));
                 }
             }
 

--- a/server/backends/households/households.php
+++ b/server/backends/households/households.php
@@ -667,7 +667,7 @@
              * @return mixed
              */
 
-            abstract function addRootPathNode($tree, $text, $icon, $type = "list");
+            abstract function addRootPathNode($tree, $text, $icon, $type = "list", $visibleForFlats = null);
 
             /**
              * @param string parentId
@@ -677,7 +677,7 @@
              * @return mixed
              */
 
-            abstract function addPathNode($parentId, $text, $icon, $type = "list");
+            abstract function addPathNode($parentId, $text, $icon, $type = "list", $visibleForFlats = null);
 
             /**
              * @param string nodeId
@@ -687,7 +687,15 @@
              * @return mixed
              */
 
-            abstract function modifyPathNode($nodeId, $text, $icon, $type = null);
+            abstract function modifyPathNode($nodeId, $text, $icon, $type = null, $visibleForFlats = false);
+
+            /**
+             * @param string nodeId
+             *
+             * @return mixed
+             */
+
+            abstract function getPathVisibleForFlats($nodeId);
 
             /**
              * @param string deviceToken

--- a/server/backends/households/internal/internal.php
+++ b/server/backends/households/internal/internal.php
@@ -3521,13 +3521,14 @@
 
                 $params["house_path_tree"] = $tree;
 
-                $nodes = $this->db->get("select house_path_id, house_path_tree, coalesce(house_path_parent, 0) house_path_parent, house_path_name, house_path_icon, coalesce(house_path_type, 'list') house_path_type, (select count (*) from houses_paths as p2 where p2.house_path_parent = p1.house_path_id) childrens from houses_paths as p1 where house_path_tree = :house_path_tree and ($query) order by house_path_name", $params, [
+                $nodes = $this->db->get("select house_path_id, house_path_tree, coalesce(house_path_parent, 0) house_path_parent, house_path_name, house_path_icon, coalesce(house_path_type, 'list') house_path_type, house_path_visible_for_flats, (select count (*) from houses_paths as p2 where p2.house_path_parent = p1.house_path_id) childrens from houses_paths as p1 where house_path_tree = :house_path_tree and ($query) order by house_path_name", $params, [
                     "house_path_id" => "id",
                     "house_path_tree" => "tree",
                     "house_path_parent" => "parentId",
                     "house_path_name" => "text",
                     "house_path_icon" => "icon",
                     "house_path_type" => "viewType",
+                    "house_path_visible_for_flats" => "visibleForFlats",
                     "childrens" => "children",
                 ]);
 
@@ -3559,7 +3560,7 @@
                 if ($withParents) {
 
                     if ((int)$treeOrFrom) {
-                        $node = $this->db->get("select house_path_id, house_path_tree, coalesce(house_path_parent, 0) house_path_parent, house_path_name, house_path_icon, coalesce(house_path_type, 'list') house_path_type, (select count (*) from houses_paths as p2 where p2.house_path_parent = p1.house_path_id) childrens from houses_paths as p1 where house_path_id = :house_path_id", [
+                        $node = $this->db->get("select house_path_id, house_path_tree, coalesce(house_path_parent, 0) house_path_parent, house_path_name, house_path_icon, coalesce(house_path_type, 'list') house_path_type, house_path_visible_for_flats, (select count (*) from houses_paths as p2 where p2.house_path_parent = p1.house_path_id) childrens from houses_paths as p1 where house_path_id = :house_path_id", [
                             "house_path_id" => $treeOrFrom,
                         ], [
                             "house_path_id" => "id",
@@ -3568,6 +3569,7 @@
                             "house_path_name" => "text",
                             "house_path_icon" => "icon",
                             "house_path_type" => "viewType",
+                            "house_path_visible_for_flats" => "visibleForFlats",
                             "childrens" => "children",
                         ], [
                             "singlify"
@@ -3581,7 +3583,7 @@
                     }
 
                     if ((int)$node["parentId"]) {
-                        $siblings = $this->db->get("select house_path_id, house_path_tree, coalesce(house_path_parent, 0) house_path_parent, house_path_name, house_path_icon, coalesce(house_path_type, 'list') house_path_type, (select count (*) from houses_paths as p2 where p2.house_path_parent = p1.house_path_id) childrens from houses_paths as p1 where house_path_parent in (select house_path_id from houses_paths where house_path_id = :house_path_id) order by house_path_name", [
+                        $siblings = $this->db->get("select house_path_id, house_path_tree, coalesce(house_path_parent, 0) house_path_parent, house_path_name, house_path_icon, coalesce(house_path_type, 'list') house_path_type, house_path_visible_for_flats, (select count (*) from houses_paths as p2 where p2.house_path_parent = p1.house_path_id) childrens from houses_paths as p1 where house_path_parent in (select house_path_id from houses_paths where house_path_id = :house_path_id) order by house_path_name", [
                             "house_path_id" => $node["parentId"],
                         ], [
                             "house_path_id" => "id",
@@ -3590,10 +3592,11 @@
                             "house_path_name" => "text",
                             "house_path_icon" => "icon",
                             "house_path_type" => "viewType",
+                            "house_path_visible_for_flats" => "visibleForFlats",
                             "childrens" => "children",
                         ]);
                     } else {
-                        $siblings = $this->db->get("select house_path_id, house_path_tree, coalesce(house_path_parent, 0) house_path_parent, house_path_name, house_path_icon, coalesce(house_path_type, 'list') house_path_type, (select count (*) from houses_paths as p2 where p2.house_path_parent = p1.house_path_id) childrens from houses_paths as p1 where house_path_parent is null and house_path_tree = :house_path_tree order by house_path_name", [
+                        $siblings = $this->db->get("select house_path_id, house_path_tree, coalesce(house_path_parent, 0) house_path_parent, house_path_name, house_path_icon, coalesce(house_path_type, 'list') house_path_type, house_path_visible_for_flats, (select count (*) from houses_paths as p2 where p2.house_path_parent = p1.house_path_id) childrens from houses_paths as p1 where house_path_parent is null and house_path_tree = :house_path_tree order by house_path_name", [
                             "house_path_tree" => $node["tree"],
                         ], [
                             "house_path_id" => "id",
@@ -3602,6 +3605,7 @@
                             "house_path_name" => "text",
                             "house_path_icon" => "icon",
                             "house_path_type" => "viewType",
+                            "house_path_visible_for_flats" => "visibleForFlats",
                             "childrens" => "children",
                         ]);
                     }
@@ -3631,7 +3635,7 @@
                     return $tree;
                 } else {
                     if (is_numeric($treeOrFrom)) {
-                        $siblings = $this->db->get("select house_path_id, house_path_tree, coalesce(house_path_parent, 0) house_path_parent, house_path_name, house_path_icon, coalesce(house_path_type, 'list') house_path_type, (select count (*) from houses_paths as p2 where p2.house_path_parent = p1.house_path_id) childrens from houses_paths as p1 where house_path_parent = :house_path_parent order by house_path_name", [
+                        $siblings = $this->db->get("select house_path_id, house_path_tree, coalesce(house_path_parent, 0) house_path_parent, house_path_name, house_path_icon, coalesce(house_path_type, 'list') house_path_type, house_path_visible_for_flats, (select count (*) from houses_paths as p2 where p2.house_path_parent = p1.house_path_id) childrens from houses_paths as p1 where house_path_parent = :house_path_parent order by house_path_name", [
                             "house_path_parent" => $treeOrFrom,
                         ], [
                             "house_path_id" => "id",
@@ -3640,10 +3644,11 @@
                             "house_path_name" => "text",
                             "house_path_icon" => "icon",
                             "house_path_type" => "viewType",
+                            "house_path_visible_for_flats" => "visibleForFlats",
                             "childrens" => "children",
                         ]);
                     } else {
-                        $siblings = $this->db->get("select house_path_id, house_path_tree, coalesce(house_path_parent, 0) house_path_parent, house_path_name, house_path_icon, coalesce(house_path_type, 'list') house_path_type, (select count (*) from houses_paths as p2 where p2.house_path_parent = p1.house_path_id) childrens from houses_paths as p1 where house_path_tree = :house_path_tree and house_path_parent is null order by house_path_name", [
+                        $siblings = $this->db->get("select house_path_id, house_path_tree, coalesce(house_path_parent, 0) house_path_parent, house_path_name, house_path_icon, coalesce(house_path_type, 'list') house_path_type, house_path_visible_for_flats, (select count (*) from houses_paths as p2 where p2.house_path_parent = p1.house_path_id) childrens from houses_paths as p1 where house_path_tree = :house_path_tree and house_path_parent is null order by house_path_name", [
                             "house_path_tree" => $treeOrFrom,
                         ], [
                             "house_path_id" => "id",
@@ -3652,6 +3657,7 @@
                             "house_path_name" => "text",
                             "house_path_icon" => "icon",
                             "house_path_type" => "viewType",
+                            "house_path_visible_for_flats" => "visibleForFlats",
                             "childrens" => "children",
                         ]);
                     }
@@ -3666,19 +3672,22 @@
              * @inheritDoc
              */
 
-            function addRootPathNode($tree, $text, $icon, $type = "list") {
+            function addRootPathNode($tree, $text, $icon, $type = "list", $visibleForFlats = null) {
                 if (!checkStr($tree) || !checkStr($text)) {
                     return false;
                 }
 
                 $type = in_array($type, [ "list", "map" ]) ? $type : "list";
 
-                return $this->db->insert("insert into houses_paths (house_path_tree, house_path_parent, house_path_name, house_path_icon, house_path_type) values (:house_path_tree, :house_path_parent, :house_path_name, :house_path_icon, :house_path_type)", [
+                $visibleForFlats = trim((string)$visibleForFlats) ?: null;
+
+                return $this->db->insert("insert into houses_paths (house_path_tree, house_path_parent, house_path_name, house_path_icon, house_path_type, house_path_visible_for_flats) values (:house_path_tree, :house_path_parent, :house_path_name, :house_path_icon, :house_path_type, :house_path_visible_for_flats)", [
                     "house_path_tree" => $tree,
                     "house_path_parent" => null,
                     "house_path_name" => $text,
                     "house_path_icon" => $icon,
                     "house_path_type" => $type,
+                    "house_path_visible_for_flats" => $visibleForFlats,
                 ]);
             }
 
@@ -3686,7 +3695,7 @@
              * @inheritDoc
              */
 
-            function addPathNode($parentId, $text, $icon, $type = "list") {
+            function addPathNode($parentId, $text, $icon, $type = "list", $visibleForFlats = null) {
                 if (!checkInt($parentId) || !checkStr($text)) {
                     return false;
                 }
@@ -3702,12 +3711,15 @@
                 ]);
 
                 if ($tree) {
-                    return $this->db->insert("insert into houses_paths (house_path_tree, house_path_parent, house_path_name, house_path_icon, house_path_type) values (:house_path_tree, :house_path_parent, :house_path_name, :house_path_icon, :house_path_type)", [
+                    $visibleForFlats = trim((string)$visibleForFlats) ?: null;
+
+                    return $this->db->insert("insert into houses_paths (house_path_tree, house_path_parent, house_path_name, house_path_icon, house_path_type, house_path_visible_for_flats) values (:house_path_tree, :house_path_parent, :house_path_name, :house_path_icon, :house_path_type, :house_path_visible_for_flats)", [
                         "house_path_tree" => $tree,
                         "house_path_parent" => $parentId,
                         "house_path_name" => $text,
                         "house_path_icon" => $icon,
                         "house_path_type" => $type,
+                        "house_path_visible_for_flats" => $visibleForFlats,
                     ]);
                 } else {
                     return false;
@@ -3718,19 +3730,67 @@
              * @inheritDoc
              */
 
-            function modifyPathNode($nodeId, $text, $icon, $type = null) {
+            function modifyPathNode($nodeId, $text, $icon, $type = null, $visibleForFlats = false) {
                 if (!checkInt($nodeId) || !checkStr($text)) {
                     return false;
                 }
 
                 $type = in_array($type, [ "list", "map" ]) ? $type : null;
 
-                return $this->db->modify("update houses_paths set house_path_name = :house_path_name, house_path_icon = :house_path_icon, house_path_type = coalesce(:house_path_type, house_path_type, 'list') where house_path_id = :house_path_id", [
+                if ($visibleForFlats === false) {
+                    return $this->db->modify("update houses_paths set house_path_name = :house_path_name, house_path_icon = :house_path_icon, house_path_type = coalesce(:house_path_type, house_path_type, 'list') where house_path_id = :house_path_id", [
+                        "house_path_id" => $nodeId,
+                        "house_path_name" => $text,
+                        "house_path_icon" => $icon,
+                        "house_path_type" => $type,
+                    ]);
+                }
+
+                $visibleForFlats = trim((string)$visibleForFlats) ?: null;
+                return $this->db->modify("update houses_paths set house_path_name = :house_path_name, house_path_icon = :house_path_icon, house_path_type = coalesce(:house_path_type, house_path_type, 'list'), house_path_visible_for_flats = :house_path_visible_for_flats where house_path_id = :house_path_id", [
                     "house_path_id" => $nodeId,
                     "house_path_name" => $text,
                     "house_path_icon" => $icon,
                     "house_path_type" => $type,
+                    "house_path_visible_for_flats" => $visibleForFlats,
                 ]);
+            }
+
+            /**
+             * @inheritDoc
+             */
+
+            function getPathVisibleForFlats($nodeId) {
+                if (!checkInt($nodeId)) {
+                    return null;
+                }
+
+                $nodeId = (int)$nodeId;
+
+                while ($nodeId) {
+                    $node = $this->db->get("select coalesce(house_path_parent, 0) house_path_parent, house_path_visible_for_flats from houses_paths where house_path_id = :house_path_id", [
+                        "house_path_id" => $nodeId,
+                    ], [
+                        "house_path_parent" => "parentId",
+                        "house_path_visible_for_flats" => "visibleForFlats",
+                    ], [
+                        "singlify"
+                    ]);
+
+                    if (!$node) {
+                        return null;
+                    }
+
+                    $visibleForFlats = trim((string)($node["visibleForFlats"] ?? ""));
+
+                    if ($visibleForFlats !== "") {
+                        return $visibleForFlats;
+                    }
+
+                    $nodeId = (int)$node["parentId"];
+                }
+
+                return null;
             }
 
             /**

--- a/server/data/install.json
+++ b/server/data/install.json
@@ -298,5 +298,8 @@
     ],
     "94": [
         "v94_subscriber_groups.sql"
+    ],
+    "95": [
+        "v95_cctv_path_visibility.sql"
     ]
 }

--- a/server/data/pgsql/current_schema.sql
+++ b/server/data/pgsql/current_schema.sql
@@ -1303,7 +1303,8 @@ CREATE TABLE public.houses_paths (
     house_path_parent integer,
     house_path_name character varying,
     house_path_icon character varying,
-    house_path_type character varying DEFAULT 'list'::character varying
+    house_path_type character varying DEFAULT 'list'::character varying,
+    house_path_visible_for_flats character varying
 );
 
 

--- a/server/data/pgsql/v95_cctv_path_visibility.sql
+++ b/server/data/pgsql/v95_cctv_path_visibility.sql
@@ -1,0 +1,1 @@
+ALTER TABLE houses_paths ADD IF NOT EXISTS house_path_visible_for_flats CHARACTER VARYING;

--- a/server/mobile/address/getAddressList.php
+++ b/server/mobile/address/getAddressList.php
@@ -45,6 +45,8 @@
     $plog = loadBackend("plog");
     $cameras = loadBackend("cameras");
 
+    require_once __DIR__ . "/../helpers/filterAvailableCameras.php";
+
     $houses = [];
 
     foreach ($subscriber['flats'] as $flat) {
@@ -65,8 +67,10 @@
             }
             $house['cameras'] = $households->getCameras("houseId", $houseId);
             $house['doors'] = [];
+            $house['flats'] = [];
         }
 
+        $house['flats'][] = $flat['flat'];
         $house['cameras'] = array_merge($house['cameras'], $households->getCameras("flatId", $flat['flatId']));
 
         $flatDetail = $households->getFlat($flat['flatId']);
@@ -107,6 +111,7 @@
     // конвертируем ассоциативные массивы в простые и удаляем лишние ключи
     foreach ($houses as $house_key => $h) {
         // count unique cameras
+        $h['cameras'] = mobile_filter_available_cameras($h['cameras'], $h['flats'], $households);
         $tempArr = array_unique(array_column($h['cameras'], 'cameraId'));
         $houses[$house_key]['cctv'] = count($tempArr);
 
@@ -128,6 +133,7 @@
         });
         $houses[$house_key]['doors'] = $doors;
         unset($houses[$house_key]['cameras']);
+        unset($houses[$house_key]['flats']);
     }
     $result = array_values($houses);
 

--- a/server/mobile/cctv/helpers/listCameras.php
+++ b/server/mobile/cctv/helpers/listCameras.php
@@ -3,6 +3,8 @@
     $cameras = loadBackend("cameras");
     $houses = [];
 
+    require_once __DIR__ . "/../../helpers/filterAvailableCameras.php";
+
     /**
      * Get stub url's from config
      * payment_require_url - stub if flat is blocked
@@ -65,8 +67,10 @@
             $house['houseId'] = strval($houseId);
             $house['cameras'] = $households->getCameras("houseId", $houseId);
             $house['doors'] = [];
+            $house['flats'] = [];
         }
 
+        $house['flats'][] = $flat['flat'];
         $house['cameras'] = array_merge($house['cameras'], $households->getCameras("flatId", $flat['flatId']));
 
         foreach ($flatDetail['entrances'] as $entrance) {
@@ -101,6 +105,8 @@
     foreach ($houses as $house_key => $h) {
         $houses[$house_key]['doors'] = array_values($h['doors']);
         unset($houses[$house_key]['cameras']);
+        unset($houses[$house_key]['flats']);
+        $h['cameras'] = mobile_filter_available_cameras($h['cameras'], $h['flats'], $households);
         foreach($h['cameras'] as $camera) {
             $dvr = loadBackend("dvr")->getDVRServerForCam($camera);
             $item = [

--- a/server/mobile/helpers/filterAvailableCameras.php
+++ b/server/mobile/helpers/filterAvailableCameras.php
@@ -1,0 +1,109 @@
+<?php
+
+    if (!function_exists("mobile_flat_matches_visible_for_flats")) {
+        function mobile_flat_matches_visible_for_flats($flat, string $visibleForFlats): bool
+        {
+            $flat = trim((string)$flat);
+
+            if ($flat === "") {
+                return false;
+            }
+
+            $flatNumber = ctype_digit($flat) ? (int)$flat : null;
+            $ranges = explode(",", $visibleForFlats);
+
+            foreach ($ranges as $range) {
+                $range = trim($range);
+
+                if ($range === "") {
+                    continue;
+                }
+
+                if (preg_match('/^(\d+)\s*-\s*(\d+)$/', $range, $matches)) {
+                    if ($flatNumber === null) {
+                        continue;
+                    }
+
+                    $from = (int)$matches[1];
+                    $to = (int)$matches[2];
+
+                    if ($from > $to) {
+                        [ $from, $to ] = [ $to, $from ];
+                    }
+
+                    if ($flatNumber >= $from && $flatNumber <= $to) {
+                        return true;
+                    }
+
+                    continue;
+                }
+
+                if ($flat === $range) {
+                    return true;
+                }
+
+                if ($flatNumber !== null && ctype_digit($range) && $flatNumber === (int)$range) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+
+    if (!function_exists("mobile_camera_path_visible_for_flats")) {
+        function mobile_camera_path_visible_for_flats(array $camera, $households): ?string
+        {
+            static $pathVisibleForFlats = [];
+
+            $path = $camera["path"] ?? null;
+
+            if (!$path) {
+                return null;
+            }
+
+            if (!array_key_exists($path, $pathVisibleForFlats)) {
+                $pathVisibleForFlats[$path] = $households->getPathVisibleForFlats($path);
+            }
+
+            $visibleForFlats = $pathVisibleForFlats[$path];
+
+            if ($visibleForFlats === null) {
+                return null;
+            }
+
+            $visibleForFlats = trim((string)$visibleForFlats);
+
+            return $visibleForFlats === "" ? null : $visibleForFlats;
+        }
+    }
+
+    if (!function_exists("mobile_filter_available_cameras")) {
+        function mobile_filter_available_cameras(array $cameras, array $flatNumbers, $households): array
+        {
+            $filtered = [];
+
+            foreach ($cameras as $camera) {
+                if (!is_array($camera)) {
+                    $filtered[] = $camera;
+                    continue;
+                }
+
+                $visibleForFlats = mobile_camera_path_visible_for_flats($camera, $households);
+
+                if ($visibleForFlats === null) {
+                    $filtered[] = $camera;
+                    continue;
+                }
+
+                foreach ($flatNumbers as $flatNumber) {
+                    if (mobile_flat_matches_visible_for_flats($flatNumber, $visibleForFlats)) {
+                        $filtered[] = $camera;
+                        continue 2;
+                    }
+                }
+            }
+
+            return $filtered;
+        }
+    }


### PR DESCRIPTION
## Summary
- add `visibleForFlats` to camera path groups via `houses_paths.house_path_visible_for_flats`
- expose the field in `houses/path` API and in the house camera group UI
- inherit empty child-group visibility from the nearest parent group
- filter house cameras in `getAddressList`, `cctv/all`, and `cctv/allTree` before URL/token generation

## Tests
- `docker run --rm -v "$PWD":/app -w /app php:8.1-cli php -l ...` for changed PHP files
- `node --check client/modules/addresses/houses.js`
- `python3 -m json.tool client/modules/addresses/i18n/ru.json`
- `python3 -m json.tool client/modules/addresses/i18n/en.json`
- `python3 -m json.tool server/data/install.json`
- `git diff --check`
- smoke-test for path visibility filtering/parsing
