### PR TITLE
[codex] Throttle mobile auth device touches

### DIFF
--- a/server/mobile.php
+++ b/server/mobile.php
@@ -231,7 +231,7 @@
     }
 
     function auth() {
-        global $_SERVER, $bearer, $subscriber, $device, $real_ip_header;
+        global $_SERVER, $bearer, $subscriber, $device, $real_ip_header, $redis;
 
         $households = loadBackend("households");
 
@@ -298,7 +298,21 @@
                 $updateDevice["version"] = $headers['X-App-Version'];
             }
 
-            $households->modifyDevice($device["deviceId"], $updateDevice);
+            $shouldUpdateDevice = true;
+
+            try {
+                $shouldUpdateDevice = (bool)$redis->set(
+                    "mobile:device-touch:" . $device["deviceId"],
+                    "1",
+                    [ "nx", "ex" => 60 ]
+                );
+            } catch (Throwable $e) {
+                $shouldUpdateDevice = true;
+            }
+
+            if ($shouldUpdateDevice) {
+                $households->modifyDevice($device["deviceId"], $updateDevice);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Add a Redis `SET NX EX` guard around the mobile `auth()` device touch update.
- Limit `ip` / `ua` / `version` updates to once per `deviceId` per 60 seconds.
- Fall back to the previous behavior and update the device when the Redis touch check fails.

## Why
Parallel mobile startup requests can all pass through `auth()` and update the same `houses_subscribers_devices` row. Throttling the touch update reduces repeated writes and row lock contention without changing auth semantics.

## Validation
- `php -l server/mobile.php`
- `git diff --check`
