### PR TITLE
Fix/zabbix intercom availability

### DIFF
--- a/install/monitoring/zabbix/templates/v6.x/intercom/zbx_intercom_template_akuvox_e12.yaml
+++ b/install/monitoring/zabbix/templates/v6.x/intercom/zbx_intercom_template_akuvox_e12.yaml
@@ -87,7 +87,7 @@ zabbix_export:
           username: '{$HOST_USERNAME}'
           password: '{$HOST_PASSWORD}'
           description: 'Get system information from Akuvox SIP intercom'
-          url: 'http://{HOST.CONN}/api/system/info'
+          url: 'http://{HOST.HOST}/api/system/info'
           triggers:
             - uuid: 8dc94ca4d548416e9ff2d68ebb9fe2d8
               expression: 'nodata(/Intercom_AKUVOX_E12/intercom.systeminfo,600)=1'
@@ -111,7 +111,7 @@ zabbix_export:
             - type: JSONPATH
               parameters:
                 - $.data.UpTime
-          url: 'http://{HOST.CONN}/api/system/status'
+          url: 'http://{HOST.HOST}/api/system/status'
         - uuid: 465125e71af844ca84bb07131a317ac9
           name: 'AKUVOX Intercom: uptime'
           type: DEPENDENT

--- a/install/monitoring/zabbix/templates/v6.x/intercom/zbx_intercom_template_beward_dks.yaml
+++ b/install/monitoring/zabbix/templates/v6.x/intercom/zbx_intercom_template_beward_dks.yaml
@@ -76,7 +76,7 @@ zabbix_export:
             - type: JAVASCRIPT
               parameters:
                 - 'return value.split("\n")[0].split("AccountReg1=")[1]'
-          url: 'http://{HOST.CONN}/cgi-bin/sip_cgi'
+          url: 'http://{HOST.HOST}/cgi-bin/sip_cgi'
           query_fields:
             - name: action
               value: regstatus
@@ -123,7 +123,7 @@ zabbix_export:
                       }
                   });
                   return JSON.stringify(data)
-          url: 'http://{HOST.CONN}/cgi-bin/systeminfo_cgi'
+          url: 'http://{HOST.HOST}/cgi-bin/systeminfo_cgi'
           query_fields:
             - name: action
               value: get

--- a/install/monitoring/zabbix/templates/v6.x/intercom/zbx_intercom_template_beward_ds.yaml
+++ b/install/monitoring/zabbix/templates/v6.x/intercom/zbx_intercom_template_beward_ds.yaml
@@ -75,7 +75,7 @@ zabbix_export:
             - type: JAVASCRIPT
               parameters:
                 - 'return value.split("\n")[0].split("AccountReg1=")[1]'
-          url: 'http://{HOST.CONN}/cgi-bin/sip_cgi'
+          url: 'http://{HOST.HOST}/cgi-bin/sip_cgi'
           query_fields:
             - name: action
               value: regstatus
@@ -115,7 +115,7 @@ zabbix_export:
                       }
                   });
                   return JSON.stringify(data)
-          url: 'http://{HOST.CONN}/cgi-bin/systeminfo_cgi'
+          url: 'http://{HOST.HOST}/cgi-bin/systeminfo_cgi'
           query_fields:
             - name: action
               value: get

--- a/install/monitoring/zabbix/templates/v6.x/intercom/zbx_intercom_template_qtech_qbr-27c-h.yaml
+++ b/install/monitoring/zabbix/templates/v6.x/intercom/zbx_intercom_template_qtech_qbr-27c-h.yaml
@@ -75,7 +75,7 @@ zabbix_export:
             - type: JSONPATH
               parameters:
                 - $.data.SipAccount.AccountStatus
-          url: 'http://{HOST.CONN}/api'
+          url: 'http://{HOST.HOST}/api'
           posts: |
             {
                 "target": "sip",
@@ -109,7 +109,7 @@ zabbix_export:
               parameters:
                 - $.body.data
               error_handler: DISCARD_VALUE
-          url: 'http://{HOST.CONN}/api'
+          url: 'http://{HOST.HOST}/api'
           posts: |
             {
                 "target": "firmware",

--- a/install/monitoring/zabbix/templates/v6.x/intercom/zbx_intercom_template_rubetek_rv-3434.yaml
+++ b/install/monitoring/zabbix/templates/v6.x/intercom/zbx_intercom_template_rubetek_rv-3434.yaml
@@ -67,17 +67,17 @@ zabbix_export:
                 - $.acc1_register_status
             - type: JAVASCRIPT
               parameters:
-                - |
-                  if (value === 'registered') {
-                      return 1;
-                  }
-
-                  if (value === 'unregistered' || value.startsWith('failed')) {
-                      return 0;
-                  }
-
-                  return value;
-          url: 'http://{HOST.CONN}/api/v1/reg_status'
+                - unregistered
+                - '0'
+            - type: STR_REPLACE
+              parameters:
+                - failed
+                - '0'
+            - type: STR_REPLACE
+              parameters:
+                - registered
+                - '1'
+          url: 'http://{HOST.HOST}/api/v1/reg_status'
           tags:
             - tag: component
               value: raw
@@ -97,7 +97,7 @@ zabbix_export:
           authtype: BASIC
           username: '{$HOST_USERNAME}'
           password: '{$HOST_PASSWORD}'
-          url: 'http://{HOST.CONN}/api/v1/version'
+          url: 'http://{HOST.HOST}/api/v1/version'
           tags:
             - tag: component
               value: raw
@@ -124,7 +124,7 @@ zabbix_export:
             - type: JSONPATH
               parameters:
                 - $.uptime
-          url: 'http://{HOST.CONN}/api/v1/intercom/check_status'
+          url: 'http://{HOST.HOST}/api/v1/intercom/check_status'
           tags:
             - tag: component
               value: raw

--- a/install/monitoring/zabbix/templates/v6.x/intercom/zbx_intercom_template_sokol_v2.yaml
+++ b/install/monitoring/zabbix/templates/v6.x/intercom/zbx_intercom_template_sokol_v2.yaml
@@ -94,7 +94,7 @@ zabbix_export:
             - type: JSONPATH
               parameters:
                 - $.body
-          url: 'http://{HOST.CONN}/system/info'
+          url: 'http://{HOST.HOST}/system/info'
           output_format: JSON
           tags:
             - tag: component
@@ -123,7 +123,7 @@ zabbix_export:
             - type: JSONPATH
               parameters:
                 - $.body
-          url: 'http://{HOST.CONN}/v2/system/versions'
+          url: 'http://{HOST.HOST}/v2/system/versions'
           output_format: JSON
           tags:
             - tag: component

--- a/install/monitoring/zabbix/templates/v6.x/intercom/zbx_intercom_template_sokol_v5.yaml
+++ b/install/monitoring/zabbix/templates/v6.x/intercom/zbx_intercom_template_sokol_v5.yaml
@@ -91,7 +91,7 @@ zabbix_export:
             - type: JSONPATH
               parameters:
                 - $.body
-          url: 'http://{HOST.CONN}/system/info'
+          url: 'http://{HOST.HOST}/system/info'
           output_format: JSON
           tags:
             - tag: component
@@ -120,7 +120,7 @@ zabbix_export:
             - type: JSONPATH
               parameters:
                 - $.body
-          url: 'http://{HOST.CONN}/v2/system/versions'
+          url: 'http://{HOST.HOST}/v2/system/versions'
           output_format: JSON
           tags:
             - tag: component

--- a/install/monitoring/zabbix/templates/v6.x/intercom/zbx_intercom_template_ufanet_secret_top.yaml
+++ b/install/monitoring/zabbix/templates/v6.x/intercom/zbx_intercom_template_ufanet_secret_top.yaml
@@ -51,7 +51,7 @@ zabbix_export:
               parameters:
                 - 'version=([0-9.]+)'
                 - \1
-          url: 'http://{HOST.CONN}:85/cgi-bin/magicBox.cgi?action=getSoftwareVersion'
+          url: 'http://{HOST.HOST}:85/cgi-bin/magicBox.cgi?action=getSoftwareVersion'
           triggers:
             - uuid: c2f094a1afba46f891bec034f8db694d
               expression: 'last(/Intercom_UFANET_SECRET_TOP/intercom.fwversion,#1)<>last(/Intercom_UFANET_SECRET_TOP/intercom.fwversion,#2) and length(last(/Intercom_UFANET_SECRET_TOP/intercom.fwversion))>0'
@@ -95,7 +95,7 @@ zabbix_export:
           authtype: BASIC
           username: '{$HOST_USERNAME}'
           password: '{$HOST_PASSWORD}'
-          url: 'http://{HOST.CONN}:85/api/v1/status'
+          url: 'http://{HOST.HOST}:85/api/v1/status'
           follow_redirects: 'NO'
           triggers:
             - uuid: 1310d677aa494d0fb720a6a55dc1fb60

--- a/install/monitoring/zabbix/templates/v7.x/intercom/zbx_intercom_template_akuvox_e12.yaml
+++ b/install/monitoring/zabbix/templates/v7.x/intercom/zbx_intercom_template_akuvox_e12.yaml
@@ -87,7 +87,7 @@ zabbix_export:
           username: '{$HOST_USERNAME}'
           password: '{$HOST_PASSWORD}'
           description: 'Get system information from Akuvox SIP intercom'
-          url: 'http://{HOST.CONN}/api/system/info'
+          url: 'http://{HOST.HOST}/api/system/info'
           triggers:
             - uuid: 8dc94ca4d548416e9ff2d68ebb9fe2d8
               expression: 'nodata(/Intercom_AKUVOX_E12/intercom.systeminfo,600)=1'
@@ -111,7 +111,7 @@ zabbix_export:
             - type: JSONPATH
               parameters:
                 - $.data.UpTime
-          url: 'http://{HOST.CONN}/api/system/status'
+          url: 'http://{HOST.HOST}/api/system/status'
         - uuid: 465125e71af844ca84bb07131a317ac9
           name: 'AKUVOX Intercom: uptime'
           type: DEPENDENT

--- a/install/monitoring/zabbix/templates/v7.x/intercom/zbx_intercom_template_beward_dks.yaml
+++ b/install/monitoring/zabbix/templates/v7.x/intercom/zbx_intercom_template_beward_dks.yaml
@@ -72,7 +72,7 @@ zabbix_export:
             - type: JAVASCRIPT
               parameters:
                 - 'return value.split("\n")[0].split("AccountReg1=")[1]'
-          url: 'http://{HOST.CONN}/cgi-bin/sip_cgi'
+          url: 'http://{HOST.HOST}/cgi-bin/sip_cgi'
           query_fields:
             - name: action
               value: regstatus
@@ -116,7 +116,7 @@ zabbix_export:
                       }
                   });
                   return JSON.stringify(data)
-          url: 'http://{HOST.CONN}/cgi-bin/systeminfo_cgi'
+          url: 'http://{HOST.HOST}/cgi-bin/systeminfo_cgi'
           query_fields:
             - name: action
               value: get

--- a/install/monitoring/zabbix/templates/v7.x/intercom/zbx_intercom_template_beward_ds.yaml
+++ b/install/monitoring/zabbix/templates/v7.x/intercom/zbx_intercom_template_beward_ds.yaml
@@ -71,7 +71,7 @@ zabbix_export:
             - type: JAVASCRIPT
               parameters:
                 - 'return value.split("\n")[0].split("AccountReg1=")[1]'
-          url: 'http://{HOST.CONN}/cgi-bin/sip_cgi'
+          url: 'http://{HOST.HOST}/cgi-bin/sip_cgi'
           query_fields:
             - name: action
               value: regstatus
@@ -110,7 +110,7 @@ zabbix_export:
                       }
                   });
                   return JSON.stringify(data)
-          url: 'http://{HOST.CONN}/cgi-bin/systeminfo_cgi'
+          url: 'http://{HOST.HOST}/cgi-bin/systeminfo_cgi'
           query_fields:
             - name: action
               value: get

--- a/install/monitoring/zabbix/templates/v7.x/intercom/zbx_intercom_template_qtech_qbr-27c-h.yaml
+++ b/install/monitoring/zabbix/templates/v7.x/intercom/zbx_intercom_template_qtech_qbr-27c-h.yaml
@@ -71,7 +71,7 @@ zabbix_export:
             - type: JSONPATH
               parameters:
                 - $.data.SipAccount.AccountStatus
-          url: 'http://{HOST.CONN}/api'
+          url: 'http://{HOST.HOST}/api'
           post_type: JSON
           posts: |
             {
@@ -104,7 +104,7 @@ zabbix_export:
               parameters:
                 - $.body.data
               error_handler: DISCARD_VALUE
-          url: 'http://{HOST.CONN}/api'
+          url: 'http://{HOST.HOST}/api'
           post_type: JSON
           posts: |
             {

--- a/install/monitoring/zabbix/templates/v7.x/intercom/zbx_intercom_template_rubetek_rv-3434.yaml
+++ b/install/monitoring/zabbix/templates/v7.x/intercom/zbx_intercom_template_rubetek_rv-3434.yaml
@@ -64,17 +64,17 @@ zabbix_export:
                 - $.acc1_register_status
             - type: JAVASCRIPT
               parameters:
-                - |
-                  if (value === 'registered') {
-                      return 1;
-                  }
-
-                  if (value === 'unregistered' || value.startsWith('failed')) {
-                      return 0;
-                  }
-
-                  return value;
-          url: 'http://{HOST.CONN}/api/v1/reg_status'
+                - unregistered
+                - '0'
+            - type: STR_REPLACE
+              parameters:
+                - failed
+                - '0'
+            - type: STR_REPLACE
+              parameters:
+                - registered
+                - '1'
+          url: 'http://{HOST.HOST}/api/v1/reg_status'
           tags:
             - tag: component
               value: raw
@@ -93,7 +93,7 @@ zabbix_export:
           authtype: BASIC
           username: '{$HOST_USERNAME}'
           password: '{$HOST_PASSWORD}'
-          url: 'http://{HOST.CONN}/api/v1/version'
+          url: 'http://{HOST.HOST}/api/v1/version'
           tags:
             - tag: component
               value: raw
@@ -120,7 +120,7 @@ zabbix_export:
             - type: JSONPATH
               parameters:
                 - $.uptime
-          url: 'http://{HOST.CONN}/api/v1/intercom/check_status'
+          url: 'http://{HOST.HOST}/api/v1/intercom/check_status'
           tags:
             - tag: component
               value: raw

--- a/install/monitoring/zabbix/templates/v7.x/intercom/zbx_intercom_template_sokol_v2.yaml
+++ b/install/monitoring/zabbix/templates/v7.x/intercom/zbx_intercom_template_sokol_v2.yaml
@@ -86,7 +86,7 @@ zabbix_export:
             - type: JSONPATH
               parameters:
                 - $.body
-          url: 'http://{HOST.CONN}/system/info'
+          url: 'http://{HOST.HOST}/system/info'
           output_format: JSON
           tags:
             - tag: component
@@ -114,7 +114,7 @@ zabbix_export:
             - type: JSONPATH
               parameters:
                 - $.body
-          url: 'http://{HOST.CONN}/v2/system/versions'
+          url: 'http://{HOST.HOST}/v2/system/versions'
           output_format: JSON
           tags:
             - tag: component

--- a/install/monitoring/zabbix/templates/v7.x/intercom/zbx_intercom_template_sokol_v5.yaml
+++ b/install/monitoring/zabbix/templates/v7.x/intercom/zbx_intercom_template_sokol_v5.yaml
@@ -84,7 +84,7 @@ zabbix_export:
             - type: JSONPATH
               parameters:
                 - $.body
-          url: 'http://{HOST.CONN}/system/info'
+          url: 'http://{HOST.HOST}/system/info'
           output_format: JSON
           tags:
             - tag: component
@@ -112,7 +112,7 @@ zabbix_export:
             - type: JSONPATH
               parameters:
                 - $.body
-          url: 'http://{HOST.CONN}/v2/system/versions'
+          url: 'http://{HOST.HOST}/v2/system/versions'
           output_format: JSON
           tags:
             - tag: component

--- a/server/backends/monitoring/zabbix/zabbix.php
+++ b/server/backends/monitoring/zabbix/zabbix.php
@@ -722,16 +722,7 @@ class zabbix extends monitoring
             $params = [
                 'host' => $item['host'],
                 'name' => $item['name'],
-                'interfaces' => [
-                    [
-                        "type" => 1,
-                        "main" => 1,
-                        "useip" => 1,
-                        "ip" => $item['interface'],
-                        "dns" => "",
-                        "port" => "10050"
-                    ]
-                ],
+                'interfaces' => [],
                 'groups' => [
                     [
                         "groupid" => $this->zbxData['groups'][$groupName]

--- a/server/backends/monitoring/zabbix/zabbix.php
+++ b/server/backends/monitoring/zabbix/zabbix.php
@@ -1189,7 +1189,7 @@ class zabbix extends monitoring
                 "host" => $item["host"],
                 "name" => $item["name"],
                 "template" => $item["parentTemplates"][0]["host"],
-                "interface" => $item["interfaces"][0]["ip"]
+                "interface" => $item["interfaces"][0]["ip"] ?? null
             ];
 
             // mapping macros


### PR DESCRIPTION
Intercom hosts are created with a Zabbix agent interface (port 10050), but no agent runs on intercoms, resulting in grey color, which is misleading.

Fix: create hosts without interfaces, replace {HOST.CONN} with {HOST.HOST} in intercom templates (works because RBT sets host technical name = IP). Also adds null coalescing for interfaces[0] to avoid crash on interface-less hosts.

Services templates (Asterisk, Flussonic, SmartYard-Server) are not changed.
