### PR TITLE
Add mobile API customization hooks

### DIFF
--- a/server/mobile.php
+++ b/server/mobile.php
@@ -131,6 +131,21 @@
         $db->exec("SET search_path TO " . $config["db"]["schema"] . ", public");
     }
 
+    /**
+     * Allow mobile API customizations to amend a value without replacing the
+     * base method. A custom endpoint can register $GLOBALS['mobileCustomizer']
+     * and then require the corresponding base endpoint.
+     *
+     * Callback signature: function (string $point, &$value, array $context): void
+     */
+    function mobileCustomize(string $point, &$value, array $context = []): void {
+        $customizer = $GLOBALS['mobileCustomizer'] ?? null;
+
+        if (is_callable($customizer)) {
+            $customizer($point, $value, $context);
+        }
+    }
+
     function response($code = 204, $data = false, $name = false, $message = false) {
 
         $response_codes = [

--- a/server/mobile/address/getSettingsList.php
+++ b/server/mobile/address/getSettingsList.php
@@ -104,6 +104,13 @@
             $f["keys"] = $households->getKeys("flatId", $f['flatId']);
         }
 
+        mobileCustomize('address.getSettingsList.flat', $f, [
+            'subscriber' => $subscriber,
+            'flat' => $flat,
+            'flatDetail' => $h_flat,
+            'isOwner' => $is_owner,
+        ]);
+
         $flats[] = $f;
     }
 

--- a/server/mobile/cctv/helpers/listCameras.php
+++ b/server/mobile/cctv/helpers/listCameras.php
@@ -47,7 +47,14 @@
             continue;
 
         $flatDetail = $households->getFlat($flat['flatId']);
-        $flatIsBlock = ($flatDetail['adminBlock'] || $flatDetail['manualBlock'] || $flatDetail['autoBlock']) && !isset($ignoreFlatBlock);
+        $flatIsBlock = $flatDetail['adminBlock'] || $flatDetail['manualBlock'] || $flatDetail['autoBlock'];
+        mobileCustomize('cctv.flatBlocked', $flatIsBlock, [
+            'subscriber' => $subscriber,
+            'flat' => $flat,
+            'flatDetail' => $flatDetail,
+            'households' => $households,
+        ]);
+        $flatIsBlock = $flatIsBlock && !isset($ignoreFlatBlock);
 
         if (array_key_exists($houseId, $houses)) {
             $house = &$houses[$houseId];

--- a/server/mobile/cctv/recPrepare.php
+++ b/server/mobile/cctv/recPrepare.php
@@ -28,6 +28,12 @@
         $houseId = $flat['addressHouseId'];
         $flatDetail = $households->getFlat($flat['flatId']);
         $flatIsBlocked = $flatDetail['adminBlock'] || $flatDetail['manualBlock'] || $flatDetail['autoBlock'];
+        mobileCustomize('cctv.flatBlocked', $flatIsBlocked, [
+            'subscriber' => $subscriber,
+            'flat' => $flat,
+            'flatDetail' => $flatDetail,
+            'households' => $households,
+        ]);
         if ($flatIsBlocked)
             continue;
 

--- a/server/mobile/ext/ext.php
+++ b/server/mobile/ext/ext.php
@@ -21,4 +21,15 @@
     */
 
     auth();
+
+    $page = null;
+    mobileCustomize('ext.ext.page', $page, [
+        'postdata' => $postdata,
+        'subscriber' => $subscriber,
+    ]);
+
+    if ($page !== null) {
+        response(200, $page);
+    }
+
     response();

--- a/server/mobile/ext/list.php
+++ b/server/mobile/ext/list.php
@@ -18,4 +18,14 @@
     */
 
     auth();
+
+    $items = [];
+    mobileCustomize('ext.list.items', $items, [
+        'subscriber' => $subscriber,
+    ]);
+
+    if ($items) {
+        response(200, $items);
+    }
+
     response();

--- a/server/mobile/ext/options.php
+++ b/server/mobile/ext/options.php
@@ -133,4 +133,9 @@
     // Face Clustering
     $response["faceClustering"] = ($config["mobile"]["face_clustering"] ?? false) ? "t" : "f";
 
+    mobileCustomize('ext.options.response', $response, [
+        'subscriber' => $subscriber,
+        'config' => $config,
+    ]);
+
     response(200, $response);


### PR DESCRIPTION
## Summary

- add a small `mobileCustomize()` callback contract to the mobile API bootstrap
- expose semantic extension points for address settings, CCTV flat blocking, extension options, extension menu items, and extension page resolution
- preserve the existing response and status-code behavior when no customizer is registered

A custom endpoint can register `$GLOBALS['mobileCustomizer']` and then `require` the corresponding base endpoint. The callback amends the value by reference, so custom code does not need to copy the base method or traverse an already-built nested response.

## Extension points

- `address.getSettingsList.flat`
- `cctv.flatBlocked`
- `ext.options.response`
- `ext.list.items`
- `ext.ext.page`

## Validation

- `php -l` on every changed PHP file
- `git diff --check`
- focused callback test for no-op behavior and by-reference mutation